### PR TITLE
Visitor validation optimizations.

### DIFF
--- a/graphql/core/validation/__init__.py
+++ b/graphql/core/validation/__init__.py
@@ -44,48 +44,92 @@ def visit_using_rules(schema, ast, rules):
     type_info = TypeInfo(schema)
     context = ValidationContext(schema, ast, type_info)
     errors = []
-    for rule in rules:
-        instance = rule(context)
-        visit(ast, ValidationVisitor(instance, type_info, errors))
+    rules = [rule(context) for rule in rules]
+    visit(ast, ValidationVisitor(rules, context, type_info, errors))
     return errors
 
 
 class ValidationVisitor(Visitor):
-    def __init__(self, instance, type_info, errors):
-        self.instance = instance
+    def __init__(self, rules, context, type_info, errors):
+        self.context = context
+        self.rules = rules
+        self.total_rules = len(rules)
         self.type_info = type_info
         self.errors = errors
+        self.ignore_children = {}
 
     def enter(self, node, key, parent, path, ancestors):
         self.type_info.enter(node)
+        to_ignore = None
+        rules_wanting_to_visit_fragment = None
 
-        if isinstance(node, FragmentDefinition) and key and hasattr(self.instance, 'visit_spread_fragments'):
-            return False
+        skipped = 0
+        for rule in self.rules:
+            if rule in self.ignore_children:
+                skipped += 1
+                continue
 
-        result = self.instance.enter(node, key, parent, path, ancestors)
-        if result and is_error(result):
-            append(self.errors, result)
-            result = False
+            visit_spread_fragments = getattr(rule, 'visit_spread_fragments', False)
 
-        if result is None and getattr(self.instance, 'visit_spread_fragments', False) and isinstance(node, FragmentSpread):
-            fragment = self.instance.context.get_fragment(node.name.value)
+            if isinstance(node, FragmentDefinition) and key and visit_spread_fragments:
+                if to_ignore is None:
+                    to_ignore = []
+
+                to_ignore.append(rule)
+                continue
+
+            result = rule.enter(node, key, parent, path, ancestors)
+
+            if result and is_error(result):
+                append(self.errors, result)
+                result = False
+
+            if result is None and visit_spread_fragments and isinstance(node, FragmentSpread):
+                if rules_wanting_to_visit_fragment is None:
+                    rules_wanting_to_visit_fragment = []
+
+                rules_wanting_to_visit_fragment.append(rule)
+
+            if result is False:
+                if to_ignore is None:
+                    to_ignore = []
+
+                to_ignore.append(rule)
+
+        if rules_wanting_to_visit_fragment:
+            fragment = self.context.get_fragment(node.name.value)
+
             if fragment:
-                visit(fragment, self)
+                sub_visitor = ValidationVisitor(rules_wanting_to_visit_fragment, self.context, self.type_info,
+                                                self.errors)
+                visit(fragment, sub_visitor)
 
-        if result is False:
+        should_skip = (len(to_ignore) if to_ignore else 0 + skipped) == self.total_rules
+
+        if should_skip:
             self.type_info.leave(node)
 
-        return result
+        elif to_ignore:
+            for rule in to_ignore:
+                self.ignore_children[rule] = node
+
+        if should_skip:
+            return False
 
     def leave(self, node, key, parent, path, ancestors):
-        result = self.instance.leave(node, key, parent, path, ancestors)
+        for rule in self.rules:
+            if rule in self.ignore_children:
+                if self.ignore_children[rule] is node:
+                    del self.ignore_children[rule]
 
-        if result and is_error(result):
-            append(self.errors, result)
-            result = False
+                continue
+
+            result = rule.leave(node, key, parent, path, ancestors)
+
+            if result and is_error(result):
+                append(self.errors, result)
 
         self.type_info.leave(node)
-        return result
 
 
 def is_error(value):


### PR DESCRIPTION
After some research into how a validation visitor works. Me and @mpaolini have come up with a more efficient way of running each validator. 

Instead of visiting the AST 22 times, let's visit the AST only once, and instead make `ValidationVisitor` a bit smart with choosing which rule enter/leave functions to run. 

When running the test suite (applying this patch against `overlapping-fields-can-be-merged`) #47), the suite runs considerably faster!

Before:

```
441 passed in 0.96 seconds 
```

After:
```
441 passed in 0.76 seconds 
```

I ran the tests about ten times each, and they all returned the same time +/- 0.01 sec.