### PR TITLE
Eliminate is_nullish as we never get a NaN in the first place.

### DIFF
--- a/graphql/core/execution/executor.py
+++ b/graphql/core/execution/executor.py
@@ -8,7 +8,6 @@ from ..language.parser import parse
 from ..language.source import Source
 from ..type import GraphQLEnumType, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, \
     GraphQLScalarType, GraphQLUnionType
-from ..utils import is_nullish
 from ..validation import validate
 from .base import ExecutionContext, ExecutionResult, ResolveInfo, Undefined, collect_fields, default_resolve_fn, \
     get_argument_values, get_field_def, get_operation_root_type
@@ -224,7 +223,7 @@ class Executor(object):
             return completed
 
         # If result is null-like, return null.
-        if is_nullish(result):
+        if result is None:
             return None
 
         # If field type is List, complete each item in the list with the inner type
@@ -248,7 +247,7 @@ class Executor(object):
         if isinstance(return_type, (GraphQLScalarType, GraphQLEnumType)):
             serialized_result = return_type.serialize(result)
 
-            if is_nullish(serialized_result):
+            if serialized_result is None:
                 return None
 
             return serialized_result

--- a/graphql/core/utils.py
+++ b/graphql/core/utils.py
@@ -32,10 +32,6 @@ def type_from_ast(schema, input_type_ast):
     return schema.get_type(input_type_ast.name.value)
 
 
-def is_nullish(value):
-    return value is None or value != value
-
-
 def pop(lst):
     if lst:
         lst.pop()
@@ -211,4 +207,4 @@ def is_valid_literal_value(type, value_ast):
 
     assert isinstance(type, (GraphQLScalarType, GraphQLEnumType)), 'Must be input type'
 
-    return not is_nullish(type.parse_literal(value_ast))
+    return type.parse_literal(value_ast) is not None


### PR DESCRIPTION
As discussed in issue #67, we should be able to do without `is_nullish` altogether, as we don't have
to deal with `NaN` internally anyway.
