### PR TITLE
Allow queries without names.

### DIFF
--- a/graphql/core/language/parser.py
+++ b/graphql/core/language/parser.py
@@ -183,9 +183,14 @@ def parse_operation_definition(parser):
         )
     operation_token = expect(parser, TokenKind.NAME)
     operation = operation_token.value
+
+    name = None
+    if not peek(parser, TokenKind.BRACE_L):
+        name = parse_name(parser)
+
     return ast.OperationDefinition(
         operation=operation,
-        name=parse_name(parser),
+        name=name,
         variable_definitions=parse_variable_definitions(parser),
         directives=parse_directives(parser),
         selection_set=parse_selection_set(parser),

--- a/tests/core_language/test_parser.py
+++ b/tests/core_language/test_parser.py
@@ -42,6 +42,11 @@ def test_parses_constant_default_values():
     assert 'Syntax Error GraphQL (1:37) Unexpected $' in str(excinfo.value)
 
 
+def test_parses_named_and_unnamed_queries():
+    parse('query Name { a }')
+    parse('query { a }')
+
+
 def test_parses_kitchen_sink():
     parse(KITCHEN_SINK)
 


### PR DESCRIPTION
Summary: Previously, only queries that looked like `query Name { ... }` were
accepted, now names like `query { ... }` are also accepted. These kinds of
queries are used by e.g. GraphiQL, so it is important for them to work.

Test plan:
- Run `PYTHONPATH=../ py.test tests`
